### PR TITLE
Added Skript Section to the generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,9 @@ plugins {
 group 'fr.skylyxx.docsgenerator'
 version '1.2.1'
 
+targetCompatibility = 8
+sourceCompatibility = 8
+
 def mcVersion = '1.13'
 def mcSubVersion = '.2'
 
@@ -20,7 +23,7 @@ repositories {
 dependencies {
     implementation(group: 'org.jetbrains', name: 'annotations', version: '16.0.2')
     implementation(group: 'org.spigotmc', name: 'spigot-api', version: mcVersion + mcSubVersion + '-R0.1-SNAPSHOT')
-    implementation('com.github.SkriptLang:Skript:2.6-beta2') {
+    implementation('com.github.SkriptLang:Skript:2.6.1') {
         exclude group: 'com.sk89q.worldguard', module: 'worldguard-legacy'
         exclude group: 'net.milkbowl.vault', module: 'Vault'
         exclude group: 'com.destroystokyo.paper', module: 'paper-api'

--- a/src/main/java/fr/skylyxx/docsgenerator/SkriptDocsGenerator.java
+++ b/src/main/java/fr/skylyxx/docsgenerator/SkriptDocsGenerator.java
@@ -28,6 +28,7 @@ public class SkriptDocsGenerator extends JavaPlugin {
     private final Collection<ExpressionInfo<?, ?>> expressions = new ArrayList<>();
     private final Collection<SyntaxElementInfo<? extends Condition>> conditions = new ArrayList<>();
     private final Collection<SkriptEventInfo<?>> events = new ArrayList<>();
+    private boolean usingSkript26;
     private Gson gson;
 
     @Override
@@ -48,6 +49,7 @@ public class SkriptDocsGenerator extends JavaPlugin {
                 Logger.severe("Missing Skript dependency ! Disabling...");
                 setEnabled(false);
             }
+            usingSkript26 = Skript.getVersion().isLargerThan(new Version("2.6"));
 
             while (Skript.isAcceptRegistrations()) {
                 Logger.warning("Waiting to Skript finish registration");
@@ -92,6 +94,10 @@ public class SkriptDocsGenerator extends JavaPlugin {
 
     public String getColored(String s) {
         return ChatColor.translateAlternateColorCodes('&', s);
+    }
+
+    public boolean isUsingSkript26() {
+        return usingSkript26;
     }
 
     public Gson getGson() {

--- a/src/main/java/fr/skylyxx/docsgenerator/types/JsonDocOutput.java
+++ b/src/main/java/fr/skylyxx/docsgenerator/types/JsonDocOutput.java
@@ -9,12 +9,14 @@ public class JsonDocOutput {
     private final List<DocumentationElement> conditions;
     private final List<EventDocumentationElement> events;
     private final List<DocumentationElement> types;
+    private final List<DocumentationElement> sections;
 
-    public JsonDocOutput(List<DocumentationElement> effects, List<DocumentationElement> expressions, List<DocumentationElement> conditions, List<EventDocumentationElement> events, List<DocumentationElement> types) {
+    public JsonDocOutput(List<DocumentationElement> effects, List<DocumentationElement> expressions, List<DocumentationElement> conditions, List<EventDocumentationElement> events, List<DocumentationElement> types, List<DocumentationElement> sections) {
         this.effects = effects;
         this.expressions = expressions;
         this.conditions = conditions;
         this.events = events;
         this.types = types;
+        this.sections = sections;
     }
 }

--- a/src/main/java/fr/skylyxx/docsgenerator/utils/DocBuilder.java
+++ b/src/main/java/fr/skylyxx/docsgenerator/utils/DocBuilder.java
@@ -169,6 +169,20 @@ public class DocBuilder {
             }
         }
 
+        List<DocumentationElement> sections = new ArrayList<>();
+        if (skriptDocsGenerator.isUsingSkript26())
+            for (SyntaxElementInfo<? extends ch.njol.skript.lang.Section> section : Skript.getSections()) {
+                SkriptAddon addon = getAddon(section);
+                if (addon == null)
+                    continue;
+                if (addon.equals(skriptAddon)) {
+                    DocumentationElement documentationElement = generateElementDoc(section);
+                    if (documentationElement == null)
+                        continue;
+                    sections.add(documentationElement);
+                }
+            }
+
         List<DocumentationElement> conditions = new ArrayList<>();
         for (SyntaxElementInfo<? extends Condition> condition : Skript.getConditions()) {
             SkriptAddon addon = getAddon(condition);
@@ -204,7 +218,7 @@ public class DocBuilder {
             }
         }
 
-        JsonDocOutput jsonDocOutput = new JsonDocOutput(effects, expressions, conditions, events, types);
+        JsonDocOutput jsonDocOutput = new JsonDocOutput(effects, expressions, conditions, events, types, sections);
         String json = skriptDocsGenerator.getGson().toJson(jsonDocOutput);
         File file = new File(skriptDocsGenerator.getDataFolder() + File.separator + skriptAddon.getName() + ".json");
         try {
@@ -220,7 +234,8 @@ public class DocBuilder {
 //        System.out.println("conditions.size() = " + conditions.size());
 //        System.out.println("events.size() = " + events.size());
 //        System.out.println("types.size() = " + types.size());
-        return effects.size() + expressions.size() + conditions.size() + events.size() + types.size();
+        return effects.size() + expressions.size() + conditions.size() + events.size() + types.size()
+                + (skriptDocsGenerator.isUsingSkript26() ? sections.size() : 0);
     }
 
     @Nullable


### PR DESCRIPTION
This small PR provides support for new Skript Sections (2.6+), as well as updated Skript dependencies (2.6-beta2 -> 2.6.1).

Tested on 2.5.3 (Still write the sections list, but empty) and, of course, 2.6.1 (write sections as normal effect)